### PR TITLE
#1506 - Generate and return policy document, depending on value of `token`.

### DIFF
--- a/src/functions/authorization/framework/handler.ts
+++ b/src/functions/authorization/framework/handler.ts
@@ -1,13 +1,28 @@
-import { CustomAuthorizerEvent, Context } from 'aws-lambda';
+import { CustomAuthorizerEvent, CustomAuthorizerResult, Context } from 'aws-lambda';
 
-export async function handler(event: CustomAuthorizerEvent, fnCtx: Context) {
+function newCustomAuthorizerResult(principalId: string, effect: string, resource: string): CustomAuthorizerResult {
+  return {
+    principalId: principalId,
+    policyDocument: {
+      Version: '2012-10-17', // default version
+      Statement: [{
+          Action: 'execute-api:Invoke', // default action
+          Effect: effect,
+          Resource: resource
+      }]
+    }
+  };
+}
+
+export async function handler(event: CustomAuthorizerEvent, fnCtx: Context): Promise<CustomAuthorizerResult> {
   const token = event.authorizationToken;
+  const userId = 'user-id';
   if (token) {
     switch (token.toLowerCase()) {
       case 'allow':
-        return true;
+        return newCustomAuthorizerResult(userId, 'Allow', event.methodArn);
       case 'deny':
-        throw Error('Not allowed');
+        return newCustomAuthorizerResult(userId, 'Deny', event.methodArn);
       case 'unauthorized':
         throw Error('unauthorized');
       default:

--- a/src/functions/authorization/framework/handler.ts
+++ b/src/functions/authorization/framework/handler.ts
@@ -13,6 +13,9 @@ const newCustomAuthorizerResult = (principalId: string, effect: string, resource
     },
   });
 
+// Note: while manually copying in to AWS Lambda, change function declaration lines to:
+// This is the roughly equivalent JS that TSC would transpile to:
+// exports.handler = async function handler(event, fnCtx) {
 export async function handler(event: CustomAuthorizerEvent, fnCtx: Context)
   : Promise<CustomAuthorizerResult> {
   const token = event.authorizationToken;

--- a/src/functions/authorization/framework/handler.ts
+++ b/src/functions/authorization/framework/handler.ts
@@ -1,20 +1,20 @@
 import { CustomAuthorizerEvent, CustomAuthorizerResult, Context } from 'aws-lambda';
 
-function newCustomAuthorizerResult(principalId: string, effect: string, resource: string): CustomAuthorizerResult {
-  return {
-    principalId: principalId,
+const newCustomAuthorizerResult = (principalId: string, effect: string, resource: string)
+  : CustomAuthorizerResult => ({
+    principalId,
     policyDocument: {
       Version: '2012-10-17', // default version
       Statement: [{
-          Action: 'execute-api:Invoke', // default action
-          Effect: effect,
-          Resource: resource
-      }]
-    }
-  };
-}
+        Action: 'execute-api:Invoke', // default action
+        Effect: effect,
+        Resource: resource,
+      }],
+    },
+  });
 
-export async function handler(event: CustomAuthorizerEvent, fnCtx: Context): Promise<CustomAuthorizerResult> {
+export async function handler(event: CustomAuthorizerEvent, fnCtx: Context)
+  : Promise<CustomAuthorizerResult> {
   const token = event.authorizationToken;
   const userId = 'user-id';
   if (token) {

--- a/src/functions/authorization/framework/handler.ts
+++ b/src/functions/authorization/framework/handler.ts
@@ -13,9 +13,6 @@ const newCustomAuthorizerResult = (principalId: string, effect: string, resource
     },
   });
 
-// Note: while manually copying in to AWS Lambda, change function declaration lines to:
-// This is the roughly equivalent JS that TSC would transpile to:
-// exports.handler = async function handler(event, fnCtx) {
 export async function handler(event: CustomAuthorizerEvent, fnCtx: Context)
   : Promise<CustomAuthorizerResult> {
   const token = event.authorizationToken;


### PR DESCRIPTION
Added the generation and returning of AWS API Gateway policy documents.  If the returned policy is invalid or the permissions are denied, the API call does not succeed. For a valid policy, API Gateway caches the returned policy, associated with the incoming token. It then uses the cached policy for the current and subsequent requests, over a pre-configured time-to-live (TTL) period of up to 3600 seconds (1 hour). You can set the TTL period to zero seconds to disable the policy caching. The default TTL value is 300 seconds (5 minutes).

This has been added so we can try out AWS Custom Authorizers in a simple fashion.  Just by passing Allow / Deny in the auth header of the request.