### PR TITLE
Removes creation of log group

### DIFF
--- a/src/functions/authoriser/framework/__tests__/createLogger.spec.ts
+++ b/src/functions/authoriser/framework/__tests__/createLogger.spec.ts
@@ -34,13 +34,11 @@ describe('Logger', () => {
 
   describe('createLogger', () => {
 
-    let createLogGroupSpy;
     let createLogStreamSpy;
     let putLogEventsSpy;
 
     beforeEach(() => {
 
-      awsSdkMock.restore('CloudWatchLogs', 'createLogGroup');
       awsSdkMock.restore('CloudWatchLogs', 'createLogStream');
       awsSdkMock.restore('CloudWatchLogs', 'putLogEvents');
 
@@ -50,55 +48,47 @@ describe('Logger', () => {
 
     it('should call the correct CloudWatchLogs methods', async () => {
 
-      createLogGroupSpy = sinon.stub().resolves(true);
       createLogStreamSpy = sinon.stub().resolves(true);
       putLogEventsSpy = sinon.stub().resolves(true);
 
-      awsSdkMock.mock('CloudWatchLogs', 'createLogGroup', createLogGroupSpy);
       awsSdkMock.mock('CloudWatchLogs', 'createLogStream', createLogStreamSpy);
       awsSdkMock.mock('CloudWatchLogs', 'putLogEvents', putLogEventsSpy);
 
       const logger = await createLogger('testLoggerName');
       logger('test error message', 'error');
 
-      expect(createLogGroupSpy.calledWith({ logGroupName: 'testLogGroupName' })).toBe(true);
       expect(createLogStreamSpy.called).toBe(true);
       expect(putLogEventsSpy.called).toBe(true);
     });
 
     it('should swallow a \"ResourceAlreadyExistsException\" error', async () => {
 
-      createLogStreamSpy = sinon.stub().resolves(true);
       putLogEventsSpy = sinon.stub().resolves(true);
 
-      awsSdkMock.mock('CloudWatchLogs', 'createLogGroup', async (params) => {
+      awsSdkMock.mock('CloudWatchLogs', 'createLogStream', async (params) => {
         throw {
           errorType: 'ResourceAlreadyExistsException',
           code: 'ResourceAlreadyExistsException',
         };
       });
-      awsSdkMock.mock('CloudWatchLogs', 'createLogStream', createLogStreamSpy);
       awsSdkMock.mock('CloudWatchLogs', 'putLogEvents', putLogEventsSpy);
 
       const logger = await createLogger('testLoggerName');
       await logger('test error message', 'error');
 
-      expect(createLogStreamSpy.called).toBe(true);
       expect(putLogEventsSpy.called).toBe(true);
     });
 
     it('should throw on any other exceptions', async (done) => {
 
-      createLogStreamSpy = sinon.stub().resolves(true);
       putLogEventsSpy = sinon.stub().resolves(true);
 
-      awsSdkMock.mock('CloudWatchLogs', 'createLogGroup', async (params) => {
+      awsSdkMock.mock('CloudWatchLogs', 'createLogStream', async (params) => {
         throw {
           errorType: 'SomeOtherException',
           code: 'SomeOtherException',
         };
       });
-      awsSdkMock.mock('CloudWatchLogs', 'createLogStream', createLogStreamSpy);
       awsSdkMock.mock('CloudWatchLogs', 'putLogEvents', putLogEventsSpy);
 
       try {

--- a/src/functions/authoriser/framework/createLogger.ts
+++ b/src/functions/authoriser/framework/createLogger.ts
@@ -25,9 +25,6 @@ async function createCloudWatchLogger(logGroupName: string, loggerName: string) 
   const cloudWatchLogs = new CloudWatchLogs();
   const logStreamName = uniqueLogStreamName(loggerName);
 
-  await cloudWatchLogs.createLogGroup({ logGroupName }).promise()
-    .catch(ignoreResourceAlreadyExistsException);
-
   await cloudWatchLogs.createLogStream({ logGroupName, logStreamName }).promise()
     .catch(ignoreResourceAlreadyExistsException);
 


### PR DESCRIPTION
Custom authoriser is currently broken as it tries to create a log group when it doesn't have permissions to do so. The custom log group will have already been created by TF so removing the creation of log groups.