### PR TITLE
Mes 2037 log employeeid failed logins

### DIFF
--- a/src/functions/authoriser/application/__tests__/verifyEmployeeId.spec.ts
+++ b/src/functions/authoriser/application/__tests__/verifyEmployeeId.spec.ts
@@ -1,12 +1,11 @@
 import * as aws from 'aws-sdk-mock';
 
-import { VerifiedTokenPayload, EmployeeIdKey, EmployeeId } from '../AdJwtVerifier';
+import { VerifiedTokenPayload, EmployeeIdKey } from '../AdJwtVerifier';
 import verifyEmployeeId from '../verifyEmployeeId';
 
 describe('verifyEmployeeId', () => {
 
   let employeeIdExtKey = 'extn.employeeId' as EmployeeIdKey;
-  let employeeId: EmployeeId;
 
   beforeEach(() => {
     employeeIdExtKey = 'extn.employeeId';
@@ -52,8 +51,6 @@ describe('verifyEmployeeId', () => {
     it('should not throw an exception when employeeid is valid', async () => {
 
       aws.mock('DynamoDB.DocumentClient', 'get', async params => ({}));
-      employeeIdExtKey = 'employeeid';
-      employeeId = '1435134';
 
       const verifiedToken: VerifiedTokenPayload = {
         sub: 'sub',
@@ -62,7 +59,7 @@ describe('verifyEmployeeId', () => {
       };
 
       try {
-        const result = await verifyEmployeeId(verifiedToken, employeeId);
+        const result = await verifyEmployeeId(verifiedToken, verifiedToken.employeeid);
         expect(result).toBeDefined();
       } catch (err) {
         fail('verifyEmployeeId should not fail when employeeid is valid');
@@ -78,7 +75,6 @@ describe('verifyEmployeeId', () => {
 
     it('should throw an exception when no employeeId found in Users table', async () => {
 
-      employeeId = '12345678';
       aws.mock('DynamoDB.DocumentClient', 'get', async params => ({}));
       const verifiedToken: VerifiedTokenPayload = {
         sub: 'sub',
@@ -87,7 +83,7 @@ describe('verifyEmployeeId', () => {
       };
 
       try {
-        const result = await verifyEmployeeId(verifiedToken, employeeId);
+        const result = await verifyEmployeeId(verifiedToken, verifiedToken['extn.employeeId']);
         expect(result).toBe(false);
       } catch (err) {
         fail('verifyEmployeeId should not fail when no employeeId found in Users table');
@@ -96,7 +92,6 @@ describe('verifyEmployeeId', () => {
 
     it('should return the verifed token when employeeId has been found', async () => {
 
-      employeeId = '12345678';
       aws.mock(
         'DynamoDB.DocumentClient',
         'get',
@@ -113,7 +108,7 @@ describe('verifyEmployeeId', () => {
       };
 
       try {
-        const result = await verifyEmployeeId(verifiedToken, employeeId);
+        const result = await verifyEmployeeId(verifiedToken, verifiedToken['extn.employeeId']);
         expect(result).toBeDefined();
       } catch (err) {
         fail(`verifyEmployeeId should not fail, error: ${err}`);

--- a/src/functions/authoriser/application/__tests__/verifyEmployeeId.spec.ts
+++ b/src/functions/authoriser/application/__tests__/verifyEmployeeId.spec.ts
@@ -1,11 +1,12 @@
 import * as aws from 'aws-sdk-mock';
 
-import { VerifiedTokenPayload, EmployeeIdKey } from '../AdJwtVerifier';
+import { VerifiedTokenPayload, EmployeeIdKey, EmployeeId } from '../AdJwtVerifier';
 import verifyEmployeeId from '../verifyEmployeeId';
 
 describe('verifyEmployeeId', () => {
 
   let employeeIdExtKey = 'extn.employeeId' as EmployeeIdKey;
+  let employeeId: EmployeeId;
 
   beforeEach(() => {
     employeeIdExtKey = 'extn.employeeId';
@@ -13,7 +14,7 @@ describe('verifyEmployeeId', () => {
   });
 
   describe('verifiedToken parameter', () => {
-    it('should throw an exception when extn.employeeId is undefined', async () => {
+    it('should throw an exception when employeeId is undefined', async () => {
 
       aws.mock('DynamoDB.DocumentClient', 'get', async params => ({}));
       const verifiedToken: VerifiedTokenPayload = {
@@ -23,8 +24,8 @@ describe('verifyEmployeeId', () => {
       };
 
       try {
-        await verifyEmployeeId(verifiedToken, employeeIdExtKey);
-        fail('verifyEmployeeId should not succeed when extn.employeeId is undefined');
+        await verifyEmployeeId(verifiedToken, verifiedToken['extn.employeeId']);
+        fail('verifyEmployeeId should not succeed when employeeId is undefined');
       } catch (err) {
         expect(err).toBe('Verified Token does not have employeeId');
       }
@@ -33,7 +34,6 @@ describe('verifyEmployeeId', () => {
     it('should throw an exception when employeeid is an empty string', async () => {
 
       aws.mock('DynamoDB.DocumentClient', 'get', async params => ({}));
-      employeeIdExtKey = 'employeeid';
 
       const verifiedToken: VerifiedTokenPayload = {
         sub: 'sub',
@@ -42,7 +42,7 @@ describe('verifyEmployeeId', () => {
       };
 
       try {
-        await verifyEmployeeId(verifiedToken, employeeIdExtKey);
+        await verifyEmployeeId(verifiedToken, verifiedToken.employeeid);
         fail('verifyEmployeeId should not succeed when employeeid is an empty string');
       } catch (err) {
         expect(err).toBe('Verified Token does not have employeeId');
@@ -53,6 +53,7 @@ describe('verifyEmployeeId', () => {
 
       aws.mock('DynamoDB.DocumentClient', 'get', async params => ({}));
       employeeIdExtKey = 'employeeid';
+      employeeId = '1435134';
 
       const verifiedToken: VerifiedTokenPayload = {
         sub: 'sub',
@@ -61,7 +62,7 @@ describe('verifyEmployeeId', () => {
       };
 
       try {
-        const result = await verifyEmployeeId(verifiedToken, employeeIdExtKey);
+        const result = await verifyEmployeeId(verifiedToken, employeeId);
         expect(result).toBeDefined();
       } catch (err) {
         fail('verifyEmployeeId should not fail when employeeid is valid');
@@ -77,6 +78,7 @@ describe('verifyEmployeeId', () => {
 
     it('should throw an exception when no employeeId found in Users table', async () => {
 
+      employeeId = '12345678';
       aws.mock('DynamoDB.DocumentClient', 'get', async params => ({}));
       const verifiedToken: VerifiedTokenPayload = {
         sub: 'sub',
@@ -85,7 +87,7 @@ describe('verifyEmployeeId', () => {
       };
 
       try {
-        const result = await verifyEmployeeId(verifiedToken, employeeIdExtKey);
+        const result = await verifyEmployeeId(verifiedToken, employeeId);
         expect(result).toBe(false);
       } catch (err) {
         fail('verifyEmployeeId should not fail when no employeeId found in Users table');
@@ -93,6 +95,8 @@ describe('verifyEmployeeId', () => {
     });
 
     it('should return the verifed token when employeeId has been found', async () => {
+
+      employeeId = '12345678';
       aws.mock(
         'DynamoDB.DocumentClient',
         'get',
@@ -109,7 +113,7 @@ describe('verifyEmployeeId', () => {
       };
 
       try {
-        const result = await verifyEmployeeId(verifiedToken, employeeIdExtKey);
+        const result = await verifyEmployeeId(verifiedToken, employeeId);
         expect(result).toBeDefined();
       } catch (err) {
         fail(`verifyEmployeeId should not fail, error: ${err}`);

--- a/src/functions/authoriser/application/verifyEmployeeId.ts
+++ b/src/functions/authoriser/application/verifyEmployeeId.ts
@@ -1,11 +1,9 @@
 import { DynamoDB } from 'aws-sdk';
-import { VerifiedTokenPayload, EmployeeIdKey } from '../application/AdJwtVerifier';
+import { VerifiedTokenPayload, EmployeeIdKey, EmployeeId } from '../application/AdJwtVerifier';
 import { extractEmployeeIdFromToken, isEmployeeIdEmptyOrNull } from './extractEmployeeIdFromToken';
 
 export default async function verifyEmployeeId(
-  verifiedToken: VerifiedTokenPayload, employeeIdExtKey: EmployeeIdKey): Promise<boolean> {
-
-  const employeeId = extractEmployeeIdFromToken(verifiedToken, employeeIdExtKey);
+  verifiedToken: VerifiedTokenPayload, employeeId: EmployeeId): Promise<boolean> {
 
   if (!employeeId || isEmployeeIdEmptyOrNull(employeeId)) {
     throw 'Verified Token does not have employeeId';


### PR DESCRIPTION
- Adds employee information to logs when available, otherwise they are set to `null`

Example log -

```
{
    "err": "The employee id was not found",
    "event": {
        "type": "TOKEN",
        "methodArn": "arn:aws:execute-api:eu-west-1:*****:******/****/GET/configuration/dev",
        "authorizationToken": "..."
    },
    "failedAuthReason": "The employee id was not found",
    "timestamp": "2019-05-31T13:58:08.344Z",
    "employee": {
        "id": "00123456",
        "name": "MESBeta User 2",
        "unique_name": "mobexaminer2@dvsagov.onmicrosoft.com"
    },
    "loggerName": "FailedAuthLogger",
    "message": "Failed authorization. Responding with Deny.",
    "level": "error"
}
```