### PR TITLE
MES-2911: Put staffNumber into AuthResponseContext

### DIFF
--- a/src/functions/authoriser/framework/__tests__/handler.spec.ts
+++ b/src/functions/authoriser/framework/__tests__/handler.spec.ts
@@ -1,5 +1,5 @@
 import { Mock, It, Times } from 'typemoq';
-import { CustomAuthorizerEvent, CustomAuthorizerResult } from 'aws-lambda';
+import { CustomAuthorizerEvent, CustomAuthorizerResult, AuthResponseContext } from 'aws-lambda';
 import AdJwtVerifier, { VerifiedTokenPayload } from '../../application/AdJwtVerifier';
 import { handler, setFailedAuthLogger } from '../handler';
 import { Logger } from '../createLogger';
@@ -88,6 +88,7 @@ describe('handler', () => {
     expect((<{ Resource: string }>result.policyDocument.Statement[0]).Resource)
       .toEqual('arn:aws:execute-api:region:account-id:api-id/stage-name/*/*');
     expect(result.principalId).toEqual('test-unique_name');
+    expect((<AuthResponseContext>result.context).staffNumber).toBe('12345678');
 
     mockAdJwtVerifier.verify(x => x.verifyJwt('example-token'), Times.once());
   });

--- a/src/functions/authoriser/framework/handler.ts
+++ b/src/functions/authoriser/framework/handler.ts
@@ -43,8 +43,14 @@ export async function handler(event: CustomAuthorizerEvent): Promise<CustomAutho
 }
 
 function createAuthResult(
-  principalId: string, effect: Effect, resource: string): CustomAuthorizerResult {
+  principalId: string, effect: Effect, resource: string,
+): CustomAuthorizerResult {
+  const staffNumber = Array.isArray(employeeId) ? employeeId[0] : employeeId;
+  const context = {
+    staffNumber,
+  };
   return {
+    context,
     principalId,
     policyDocument: {
       Version: '2012-10-17', // default version


### PR DESCRIPTION
* The `staffNumber` can then be consumed from the request context of downstream functions