### PR TITLE
MES-3059: Remove zero padding from staff number received from JWT

### DIFF
--- a/src/functions/authoriser/application/AdJwtVerifier.ts
+++ b/src/functions/authoriser/application/AdJwtVerifier.ts
@@ -1,7 +1,7 @@
 import { decode, verify } from 'jsonwebtoken';
 
 export type EmployeeIdKey = 'extn.employeeId' | 'employeeid';
-export type EmployeeId = string[] | string | null;
+export type EmployeeId = string;
 
 export interface JsonWebKey {
   readonly kid: string;

--- a/src/functions/authoriser/application/__tests__/extractEmployeeIdFromToken.spec.ts
+++ b/src/functions/authoriser/application/__tests__/extractEmployeeIdFromToken.spec.ts
@@ -1,0 +1,105 @@
+import { extractEmployeeIdFromToken } from '../extractEmployeeIdFromToken';
+import { VerifiedTokenPayload } from '../AdJwtVerifier';
+
+describe('extractEmployeeIdFromToken', () => {
+  const token: VerifiedTokenPayload = {
+    sub: 'sub',
+    unique_name: 'unique_name',
+    'extn.employeeId': ['12345678'],
+  };
+
+  it('should return null if they payload does not have a property for the employeeId key', () => {
+    const result = extractEmployeeIdFromToken(token, 'employeeid');
+
+    expect(result).toBeNull();
+  });
+
+  it('should return null when the employeeId is a null property in the JWT payload', () => {
+    const nullEmployeeIdToken: VerifiedTokenPayload = { ...token, employeeid: null };
+
+    const result = extractEmployeeIdFromToken(nullEmployeeIdToken, 'employeeid');
+
+    expect(result).toBeNull();
+  });
+
+  it('should return null when the employeeId is an empty string', () => {
+    const emptyEmployeeIdToken: VerifiedTokenPayload = { ...token, employeeid: '' };
+
+    const result = extractEmployeeIdFromToken(emptyEmployeeIdToken, 'employeeid');
+
+    expect(result).toBeNull();
+  });
+
+  it('should return null when the employeeId is a blank string', () => {
+    const blankEmployeeIdToken: VerifiedTokenPayload = { ...token, employeeid: '  ' };
+
+    const result = extractEmployeeIdFromToken(blankEmployeeIdToken, 'employeeid');
+
+    expect(result).toBeNull();
+  });
+
+  it('should return null when the employeeId key maps to an empty array', () => {
+    const emptyArrayEmployeeIdToken: VerifiedTokenPayload = { ...token, employeeid: [] };
+
+    const result = extractEmployeeIdFromToken(emptyArrayEmployeeIdToken, 'employeeid');
+
+    expect(result).toBeNull();
+  });
+
+  it('should return null when employeeId is an array containing a single null', () => {
+    const nullArrayEmployeeIdToken: VerifiedTokenPayload = { ...token, employeeid: [null] };
+
+    const result = extractEmployeeIdFromToken(nullArrayEmployeeIdToken, 'employeeid');
+
+    expect(result).toBeNull();
+  });
+
+  it('should return null when employeeId is an array containing a single empty string', () => {
+    const singleEmptyArrayEmployeeIdToken: VerifiedTokenPayload = { ...token, employeeid: [''] };
+
+    const result = extractEmployeeIdFromToken(singleEmptyArrayEmployeeIdToken, 'employeeid');
+
+    expect(result).toBeNull();
+  });
+
+  it('should return null when employeeId is an array containing a single blank string', () => {
+    const singleBlankArrayEmployeeIdToken: VerifiedTokenPayload = { ...token, employeeid: ['  '] };
+
+    const result = extractEmployeeIdFromToken(singleBlankArrayEmployeeIdToken, 'employeeid');
+
+    expect(result).toBeNull();
+  });
+
+  it('should return null when the employeeId value is a non-numeric string', () => {
+    const singleNonNumArrayEmployeeIdToken: VerifiedTokenPayload = { ...token, employeeid: 'o123' };
+
+    const result = extractEmployeeIdFromToken(singleNonNumArrayEmployeeIdToken, 'employeeid');
+
+    expect(result).toBeNull();
+  });
+
+  it('should return the employeeId when its a string of a number', () => {
+    const singleNumberArrayEmployeeIdToken: VerifiedTokenPayload = { ...token, employeeid: '123' };
+
+    const result = extractEmployeeIdFromToken(singleNumberArrayEmployeeIdToken, 'employeeid');
+
+    expect(result).toBe('123');
+  });
+
+  it('should return the employeeId with leading zeroes stripped when it has leading zeroes', () => {
+    const singleZeroPaddedNumArrayEmployeeIdToken: VerifiedTokenPayload = { ...token, employeeid: '00123' };
+
+    const result = extractEmployeeIdFromToken(singleZeroPaddedNumArrayEmployeeIdToken, 'employeeid');
+
+    expect(result).toBe('123');
+  });
+
+  it('should return the first employeeId encountered if the property is an array', () => {
+    const multiArrayEmployeeIdToken: VerifiedTokenPayload = { ...token, employeeid: ['00999', 'o111'] };
+
+    const result = extractEmployeeIdFromToken(multiArrayEmployeeIdToken, 'employeeid');
+
+    expect(result).toBe('999');
+  });
+
+});

--- a/src/functions/authoriser/application/__tests__/verifyEmployeeId.spec.ts
+++ b/src/functions/authoriser/application/__tests__/verifyEmployeeId.spec.ts
@@ -5,61 +5,17 @@ import verifyEmployeeId from '../verifyEmployeeId';
 
 describe('verifyEmployeeId', () => {
 
-  let employeeIdExtKey = 'extn.employeeId' as EmployeeIdKey;
-
   beforeEach(() => {
-    employeeIdExtKey = 'extn.employeeId';
     aws.restore('DynamoDB.DocumentClient');
   });
 
   describe('verifiedToken parameter', () => {
-    it('should throw an exception when employeeId is undefined', async () => {
-
-      aws.mock('DynamoDB.DocumentClient', 'get', async params => ({}));
-      const verifiedToken: VerifiedTokenPayload = {
-        sub: 'sub',
-        unique_name: 'unique_name',
-        'extn.employeeId': [],
-      };
-
-      try {
-        await verifyEmployeeId(verifiedToken, verifiedToken['extn.employeeId']);
-        fail('verifyEmployeeId should not succeed when employeeId is undefined');
-      } catch (err) {
-        expect(err).toBe('Verified Token does not have employeeId');
-      }
-    });
-
-    it('should throw an exception when employeeid is an empty string', async () => {
-
-      aws.mock('DynamoDB.DocumentClient', 'get', async params => ({}));
-
-      const verifiedToken: VerifiedTokenPayload = {
-        sub: 'sub',
-        unique_name: 'unique_name',
-        employeeid: '',
-      };
-
-      try {
-        await verifyEmployeeId(verifiedToken, verifiedToken.employeeid);
-        fail('verifyEmployeeId should not succeed when employeeid is an empty string');
-      } catch (err) {
-        expect(err).toBe('Verified Token does not have employeeId');
-      }
-    });
-
     it('should not throw an exception when employeeid is valid', async () => {
 
       aws.mock('DynamoDB.DocumentClient', 'get', async params => ({}));
 
-      const verifiedToken: VerifiedTokenPayload = {
-        sub: 'sub',
-        unique_name: 'unique_name',
-        employeeid: '1435134',
-      };
-
       try {
-        const result = await verifyEmployeeId(verifiedToken, verifiedToken.employeeid);
+        const result = await verifyEmployeeId('1435134');
         expect(result).toBeDefined();
       } catch (err) {
         fail('verifyEmployeeId should not fail when employeeid is valid');
@@ -68,22 +24,11 @@ describe('verifyEmployeeId', () => {
   });
 
   describe('dynamo db get', () => {
-    beforeEach(() => {
-      employeeIdExtKey = 'extn.employeeId';
-      aws.restore('DynamoDB.DocumentClient');
-    });
-
-    it('should throw an exception when no employeeId found in Users table', async () => {
-
+    it('should return false when no employeeId found in Users table', async () => {
       aws.mock('DynamoDB.DocumentClient', 'get', async params => ({}));
-      const verifiedToken: VerifiedTokenPayload = {
-        sub: 'sub',
-        unique_name: 'unique_name',
-        'extn.employeeId': ['12345678'],
-      };
 
       try {
-        const result = await verifyEmployeeId(verifiedToken, verifiedToken['extn.employeeId']);
+        const result = await verifyEmployeeId('12345678');
         expect(result).toBe(false);
       } catch (err) {
         fail('verifyEmployeeId should not fail when no employeeId found in Users table');
@@ -91,7 +36,6 @@ describe('verifyEmployeeId', () => {
     });
 
     it('should return the verifed token when employeeId has been found', async () => {
-
       aws.mock(
         'DynamoDB.DocumentClient',
         'get',
@@ -101,18 +45,14 @@ describe('verifyEmployeeId', () => {
           },
         }),
       );
-      const verifiedToken: VerifiedTokenPayload = {
-        sub: 'sub',
-        unique_name: 'unique_name',
-        'extn.employeeId': ['12345678'],
-      };
 
       try {
-        const result = await verifyEmployeeId(verifiedToken, verifiedToken['extn.employeeId']);
+        const result = await verifyEmployeeId('12345678');
         expect(result).toBeDefined();
       } catch (err) {
         fail(`verifyEmployeeId should not fail, error: ${err}`);
       }
     });
   });
+
 });

--- a/src/functions/authoriser/application/extractEmployeeIdFromToken.ts
+++ b/src/functions/authoriser/application/extractEmployeeIdFromToken.ts
@@ -2,15 +2,37 @@ import { VerifiedTokenPayload, EmployeeIdKey, EmployeeId } from './AdJwtVerifier
 
 export const extractEmployeeIdFromToken = (
   verifiedToken: VerifiedTokenPayload,
-  employeeIdKey: EmployeeIdKey): EmployeeId | null => {
-
+  employeeIdKey: EmployeeIdKey,
+): EmployeeId | null => {
   const employeeId = verifiedToken[employeeIdKey];
-  return Array.isArray(employeeId) ? employeeId[0] : employeeId;
+  if (typeof employeeId !== 'string' && !Array.isArray(employeeId)) {
+    return null;
+  }
 
+  if (typeof employeeId === 'string') {
+    return extractEmployeeIdFromString(employeeId);
+  }
+  return extractEmployeeIdFromArray(employeeId);
 };
 
-export const isEmployeeIdEmptyOrNull = (employeeId: EmployeeId): boolean => {
-  if (Array.isArray(employeeId)) return employeeId.length === 0;
-  if (typeof employeeId === 'string') return employeeId === '';
-  throw new Error('Provided employee id is neither an array or a string');
+const extractEmployeeIdFromString = (employeeIdClaim: string): string | null => {
+  if (employeeIdClaim.trim().length === 0) {
+    return null;
+  }
+  const numericEmployeeId = Number.parseInt(employeeIdClaim, 10);
+  if (Number.isNaN(numericEmployeeId)) {
+    return null;
+  }
+  return numericEmployeeId.toString();
+};
+
+const extractEmployeeIdFromArray = (employeeIdClaimArr: any[]): string | null => {
+  if (employeeIdClaimArr.length === 0) {
+    return null;
+  }
+  const firstClaim = employeeIdClaimArr[0];
+  if (typeof firstClaim !== 'string') {
+    return null;
+  }
+  return extractEmployeeIdFromString(firstClaim);
 };

--- a/src/functions/authoriser/application/getExaminerRole.ts
+++ b/src/functions/authoriser/application/getExaminerRole.ts
@@ -1,14 +1,9 @@
-import { isEmployeeIdEmptyOrNull } from './extractEmployeeIdFromToken';
 import { EmployeeId } from './AdJwtVerifier';
 import { createDynamoClient, getUsersTableName } from './verifyEmployeeId';
 
 export default async function getExaminerRole(employeeId: EmployeeId): Promise<string> {
   const role: string = 'role';
   const DE: string = 'DE';
-
-  if (!employeeId || isEmployeeIdEmptyOrNull(employeeId)) {
-    throw 'Verified Token does not have employeeId';
-  }
 
   const ddb = createDynamoClient();
   const result = await ddb.get({

--- a/src/functions/authoriser/application/verifyEmployeeId.ts
+++ b/src/functions/authoriser/application/verifyEmployeeId.ts
@@ -1,13 +1,9 @@
 import { DynamoDB } from 'aws-sdk';
-import { VerifiedTokenPayload, EmployeeId } from '../application/AdJwtVerifier';
-import { isEmployeeIdEmptyOrNull } from './extractEmployeeIdFromToken';
+import { EmployeeId } from '../application/AdJwtVerifier';
 
 export default async function verifyEmployeeId(
-  verifiedToken: VerifiedTokenPayload, employeeId: EmployeeId): Promise<boolean> {
-
-  if (!employeeId || isEmployeeIdEmptyOrNull(employeeId)) {
-    throw 'Verified Token does not have employeeId';
-  }
+  employeeId: EmployeeId,
+): Promise<boolean> {
 
   const ddb = createDynamoClient();
   const result = await ddb.get({

--- a/src/functions/authoriser/framework/__tests__/handler.spec.ts
+++ b/src/functions/authoriser/framework/__tests__/handler.spec.ts
@@ -26,7 +26,7 @@ describe('handler', () => {
     mockGetExaminerRole.reset();
 
     mockAdJwtVerifier.setup((x: any) => x.then).returns(() => undefined); // TypeMoq limitation
-    mockVerifyEmployeeId.setup(x => x(It.isAny(), It.isAny()))
+    mockVerifyEmployeeId.setup(x => x(It.isAny()))
       .returns(() => Promise.resolve(true));
     mockGetEmployeeIdKey.setup(x => x()).returns(() => 'employeeid');
     mockGetExaminerRole.setup(x => x(It.isAnyString())).returns(() => Promise.resolve('LDTM'));

--- a/src/functions/authoriser/framework/__tests__/handler.spec.ts
+++ b/src/functions/authoriser/framework/__tests__/handler.spec.ts
@@ -7,6 +7,7 @@ import * as createAdJwtVerifier from '../createAdJwtVerifier';
 import * as verifyEmployeeId from '../../application/verifyEmployeeId';
 import * as getEmployeeIdKey from '../../application/getEmployeeIdKey';
 import * as getExaminerRole from '../../application/getExaminerRole';
+import * as extractEmployeeIdFromToken from '../../application/extractEmployeeIdFromToken';
 
 describe('handler', () => {
   const moqFailedAuthLogger = Mock.ofType<Logger>();
@@ -14,6 +15,7 @@ describe('handler', () => {
   const mockVerifyEmployeeId = Mock.ofInstance(verifyEmployeeId.default);
   const mockGetEmployeeIdKey = Mock.ofInstance(getEmployeeIdKey.default);
   const mockGetExaminerRole = Mock.ofInstance(getExaminerRole.default);
+  const moqExtractEmployeeIdFromToken = Mock.ofInstance(extractEmployeeIdFromToken.extractEmployeeIdFromToken);
   let testCustomAuthorizerEvent: CustomAuthorizerEvent;
 
   const sut = handler;
@@ -24,12 +26,14 @@ describe('handler', () => {
     mockVerifyEmployeeId.reset();
     mockGetEmployeeIdKey.reset();
     mockGetExaminerRole.reset();
+    moqExtractEmployeeIdFromToken.reset();
 
     mockAdJwtVerifier.setup((x: any) => x.then).returns(() => undefined); // TypeMoq limitation
     mockVerifyEmployeeId.setup(x => x(It.isAny()))
       .returns(() => Promise.resolve(true));
     mockGetEmployeeIdKey.setup(x => x()).returns(() => 'employeeid');
     mockGetExaminerRole.setup(x => x(It.isAnyString())).returns(() => Promise.resolve('LDTM'));
+    moqExtractEmployeeIdFromToken.setup(x => x(It.isAny(), It.isAny())).returns(() => '12345678');
 
     testCustomAuthorizerEvent = {
       type: 'type',
@@ -43,6 +47,7 @@ describe('handler', () => {
     spyOn(verifyEmployeeId, 'default').and.callFake(mockVerifyEmployeeId.object);
     spyOn(getEmployeeIdKey, 'default').and.callFake(mockGetEmployeeIdKey.object);
     spyOn(getExaminerRole, 'default').and.callFake(mockGetExaminerRole.object);
+    spyOn(extractEmployeeIdFromToken, 'extractEmployeeIdFromToken').and.callFake(moqExtractEmployeeIdFromToken.object);
 
     setFailedAuthLogger(moqFailedAuthLogger.object);
   });
@@ -87,6 +92,8 @@ describe('handler', () => {
     // ASSERT
     moqFailedAuthLogger.verify(x => x(It.isAny(), It.isAny()), Times.never());
     moqFailedAuthLogger.verify(x => x(It.isAny(), It.isAny(), It.isAny()), Times.never());
+    mockGetExaminerRole.verify(x => x(It.isValue(testVerifiedTokenPayload.employeeid)), Times.once());
+    mockVerifyEmployeeId.verify(x => x(It.isValue(testVerifiedTokenPayload.employeeid)), Times.once());
 
     expect(result.policyDocument.Statement[0].Effect).toEqual('Allow');
     expect((<{ Resource: string }>result.policyDocument.Statement[0]).Resource)
@@ -121,6 +128,38 @@ describe('handler', () => {
         It.is<string>(s => /Failed authorization\. Responding with Deny\./.test(s)),
         'error',
         It.is<any>(o => /Example invalid token error/.test(o.failedAuthReason))),
+      Times.once());
+  });
+
+  it('should return Deny when the employeeId cannot be found in the JWT', async () => {
+    // ARRANGE
+    testCustomAuthorizerEvent.authorizationToken = 'example-token';
+    testCustomAuthorizerEvent.methodArn =
+      'arn:aws:execute-api:region:account-id:api-id/stage-name/HTTP-VERB/resource/path/specifier';
+    moqExtractEmployeeIdFromToken.reset();
+    moqExtractEmployeeIdFromToken.setup(x => x(It.isAny(), It.isAny())).returns(() => null);
+    const testVerifiedTokenPayload: VerifiedTokenPayload = {
+      sub: 'test-subject',
+      unique_name: 'test-unique_name',
+      employeeid: '12345678',
+    };
+    mockAdJwtVerifier.setup(x => x.verifyJwt(It.isAny()))
+      .returns(() => Promise.resolve(testVerifiedTokenPayload));
+
+    // ACT
+    const result = await sut(testCustomAuthorizerEvent);
+
+    // ASSERT
+    expect(result.policyDocument.Statement[0].Effect).toEqual('Deny');
+    expect((<{ Resource: string }>result.policyDocument.Statement[0]).Resource)
+      .toEqual('arn:aws:execute-api:region:account-id:api-id/stage-name/*/*');
+    expect(result.principalId).toEqual('not-authorized');
+    mockAdJwtVerifier.verify(x => x.verifyJwt('example-token'), Times.once());
+    moqFailedAuthLogger.verify(
+      x => x(
+        It.is<string>(s => /Failed authorization\. Responding with Deny\./.test(s)),
+        'error',
+        It.is<any>(o => /Verified Token does not have employeeId/.test(o.failedAuthReason))),
       Times.once());
   });
 });

--- a/src/functions/authoriser/framework/handler.ts
+++ b/src/functions/authoriser/framework/handler.ts
@@ -33,7 +33,6 @@ export async function handler(event: CustomAuthorizerEvent): Promise<CustomAutho
   try {
     verifiedToken = await adJwtVerifier.verifyJwt(token);
     employeeId = extractEmployeeIdFromToken(verifiedToken, employeeIdExtKey);
-
     if (employeeId === null) {
       throw new Error('Verified Token does not have employeeId');
     }

--- a/src/functions/authoriser/framework/handler.ts
+++ b/src/functions/authoriser/framework/handler.ts
@@ -52,7 +52,7 @@ export async function handler(event: CustomAuthorizerEvent): Promise<CustomAutho
 function createAuthResult(
   principalId: string, effect: Effect, resource: string,
 ): CustomAuthorizerResult {
-  const staffNumber = Array.isArray(employeeId) ? employeeId[0] : employeeId;
+  const staffNumber = employeeId;
   const context = {
     staffNumber,
     examinerRole,

--- a/src/functions/authoriser/framework/handler.ts
+++ b/src/functions/authoriser/framework/handler.ts
@@ -13,7 +13,7 @@ type Effect = 'Allow' | 'Deny';
 
 let adJwtVerifier: AdJwtVerifier | null = null;
 let failedAuthLogger: Logger | null = null;
-let employeeId: EmployeeId;
+let employeeId: EmployeeId | null;
 let examinerRole: string;
 let verifiedToken: VerifiedTokenPayload;
 
@@ -33,8 +33,13 @@ export async function handler(event: CustomAuthorizerEvent): Promise<CustomAutho
   try {
     verifiedToken = await adJwtVerifier.verifyJwt(token);
     employeeId = extractEmployeeIdFromToken(verifiedToken, employeeIdExtKey);
+
+    if (employeeId === null) {
+      throw new Error('Verified Token does not have employeeId');
+    }
+
     examinerRole = await getExaminerRole(employeeId);
-    const result = await verifyEmployeeId(verifiedToken, employeeId);
+    const result = await verifyEmployeeId(employeeId);
 
     if (!result) {
       return handleError('The employee id was not found', event, methodArn);


### PR DESCRIPTION
* Refactor `extractEmployeeIdFromToken` to encapsulate entire employeeId
  claim parsing procedure, including removing leading zeroes
* Tidy up confusion about the type of an `EmployeeId`, it was never
  `string[]`
* Catch problems parsing an employeeId at the top level, don't handle it
  multiple downstream calls
* Remove unused `VerifiedTokenPayload` param from call to `verifyEmployeeId`
* **Should be merged at the same time as equivalent changes to journal test data**