### PR TITLE
MES-5946: Pass principalId (User email address) in auth result for logging

### DIFF
--- a/component-tests/steps/authoriseSteps.ts
+++ b/component-tests/steps/authoriseSteps.ts
@@ -18,7 +18,7 @@ interface AuthoriseStepsContext {
   testAppId: string;
   testIssuer: string;
   testKid: string;
-  testTokenUniqueName: string;
+  testTokenPreferredUsername: string;
   testTokenSubject: string;
   token: string;
   methodArn: string;
@@ -43,7 +43,7 @@ Given('a custom authoriser lambda', function () {
     testAppId: uuid(),
     testIssuer: uuid(),
     testKid: uuid(),
-    testTokenUniqueName: uuid(),
+    testTokenPreferredUsername: uuid(),
     testTokenSubject: uuid(),
     token: 'token-not-set',
     methodArn: 'arn:aws:dummy:method:arn/stage/VERB/some/path',
@@ -142,7 +142,7 @@ Given('the token\'s payload is changed', function () {
   const parts = context.token.split('.');
 
   const payload = base64Decode(parts[1]);
-  payload['unique_name'] = uuid();
+  payload['preferred_username'] = uuid();
   parts[1] = base64Encode(payload).replace('=', '');
 
   context.token = parts.join('.');
@@ -187,7 +187,7 @@ Then('the result should Allow access', function () {
   context.moqFailedAuthLogger.verify(x => x(It.isAny(), It.isAny(), It.isAny()), Times.never());
 
   expect(result.policyDocument.Statement[0].Effect).to.equal('Allow');
-  expect(result.principalId).to.equal(context.testTokenUniqueName);
+  expect(result.principalId).to.equal(context.testTokenPreferredUsername);
 });
 
 Then('the result should Deny access', function () {
@@ -231,7 +231,7 @@ const createToken = (
   audience?: string,
   employeeId?: string): string => {
   const payload = {
-    unique_name: context.testTokenUniqueName,
+    preferred_username: context.testTokenPreferredUsername,
     'extn.employeeId': employeeId ? [employeeId] : undefined,
   };
 

--- a/src/functions/authoriser/application/AdJwtVerifier.ts
+++ b/src/functions/authoriser/application/AdJwtVerifier.ts
@@ -15,7 +15,7 @@ export interface JwksClient {
 
 export type BaseVerifiedTokenPayload = {
   readonly sub: string;
-  readonly unique_name: string;
+  readonly preferred_username: string;
   readonly [index: string]: any;
 };
 

--- a/src/functions/authoriser/application/__tests__/AdJwtVerifier.spec.ts
+++ b/src/functions/authoriser/application/__tests__/AdJwtVerifier.spec.ts
@@ -25,7 +25,7 @@ describe('AdJwtVerifier', () => {
     moqJwtVerify.setup(x => x(It.isAnyString(), It.isAnyString(), It.isAny()))
       .returns(() => ({
         sub: 'test-subject',
-        unique_name: 'test-unique_name',
+        preferred_username: 'test-preferred-username',
         'extn.employeeId': [
           'employeeId',
         ],
@@ -60,7 +60,7 @@ describe('AdJwtVerifier', () => {
         Times.once());
 
       expect(result.sub).toBe('test-subject');
-      expect(result.unique_name).toBe('test-unique_name');
+      expect(result.preferred_username).toBe('test-preferred-username');
     });
 
     it('uses publicKey over rsaPublicKey if they\'re both defined', async () => {

--- a/src/functions/authoriser/application/__tests__/extractEmployeeIdFromToken.spec.ts
+++ b/src/functions/authoriser/application/__tests__/extractEmployeeIdFromToken.spec.ts
@@ -4,7 +4,7 @@ import { VerifiedTokenPayload } from '../AdJwtVerifier';
 describe('extractEmployeeIdFromToken', () => {
   const token: VerifiedTokenPayload = {
     sub: 'sub',
-    unique_name: 'unique_name',
+    preferred_username: 'preferred_username',
     'extn.employeeId': ['12345678'],
     roles: [],
   };

--- a/src/functions/authoriser/application/__tests__/extractEmployeeRolesFromToken.spec.ts
+++ b/src/functions/authoriser/application/__tests__/extractEmployeeRolesFromToken.spec.ts
@@ -4,7 +4,7 @@ import { extractEmployeeRolesFromToken, hasDelegatedExaminerRole } from '../extr
 describe('extractEmployeeRolesFromToken', () => {
   const token: Partial<VerifiedTokenPayload> = {
     sub: 'sub',
-    unique_name: 'unique_name',
+    preferred_username: 'preferred_username',
     employeeid: '1234567',
   };
 
@@ -25,7 +25,7 @@ describe('extractEmployeeRolesFromToken', () => {
 describe('hasDelegatedExaminerRole', () => {
   const token: Partial<VerifiedTokenPayload> = {
     sub: 'sub',
-    unique_name: 'unique_name',
+    preferred_username: 'preferred_username',
     employeeid: '1234567',
   };
 

--- a/src/functions/authoriser/framework/__tests__/handler.spec.ts
+++ b/src/functions/authoriser/framework/__tests__/handler.spec.ts
@@ -79,7 +79,7 @@ describe('handler', () => {
 
     const testVerifiedTokenPayload: VerifiedTokenPayload = {
       sub: 'test-subject',
-      unique_name: 'test-unique_name',
+      preferred_username: 'test-preferred-username',
       employeeid: '12345678',
       roles: [],
     };
@@ -107,7 +107,7 @@ describe('handler', () => {
     expect(result.policyDocument.Statement[0].Effect).toEqual('Allow');
     expect((<{ Resource: string }>result.policyDocument.Statement[0]).Resource)
       .toEqual('arn:aws:execute-api:region:account-id:api-id/stage-name/*/*');
-    expect(result.principalId).toEqual('test-unique_name');
+    expect(result.principalId).toEqual('test-preferred-username');
     expect((<AuthResponseContext>result.context).staffNumber).toBe('12345678');
     expect((<AuthResponseContext>result.context).examinerRole).toBe('LDTM');
 
@@ -121,7 +121,7 @@ describe('handler', () => {
 
     const testVerifiedTokenPayload: VerifiedTokenPayload = {
       sub: 'test-subject',
-      unique_name: 'test-unique_name',
+      preferred_username: 'test-preferred-username',
       employeeid: '12345678',
       roles: [],
     };
@@ -144,7 +144,7 @@ describe('handler', () => {
     expect(result.policyDocument.Statement[0].Effect).toEqual('Allow');
     expect((<{ Resource: string }>result.policyDocument.Statement[0]).Resource)
       .toEqual('arn:aws:execute-api:region:account-id:api-id/stage-name/*/*');
-    expect(result.principalId).toEqual('test-unique_name');
+    expect(result.principalId).toEqual('test-preferred-username');
     expect((<AuthResponseContext>result.context).staffNumber).toBe('12345678');
     expect((<AuthResponseContext>result.context).examinerRole).toBe('DE');
 
@@ -196,7 +196,7 @@ describe('handler', () => {
     moqExtractEmployeeIdFromToken.setup(x => x(It.isAny(), It.isAny())).returns(() => null);
     const testVerifiedTokenPayload: VerifiedTokenPayload = {
       sub: 'test-subject',
-      unique_name: 'test-unique_name',
+      preferred_username: 'test-preferred-username',
       employeeid: '12345678',
       roles: [],
     };
@@ -234,7 +234,7 @@ describe('handler', () => {
       'arn:aws:execute-api:region:account-id:api-id/stage-name/HTTP-VERB/resource/path/specifier';
     const testVerifiedTokenPayload: VerifiedTokenPayload = {
       sub: 'test-subject',
-      unique_name: 'test-unique_name',
+      preferred_username: 'test-preferred-username',
       employeeid: '12345678',
       roles: [],
     };

--- a/src/functions/authoriser/framework/handler.ts
+++ b/src/functions/authoriser/framework/handler.ts
@@ -42,7 +42,7 @@ export async function handler(event: CustomAuthorizerEvent): Promise<CustomAutho
 
     if (hasDelegatedExaminerRole(verifiedToken)) {
       examinerRole = DLG;
-      return createAuthResult(verifiedToken.unique_name, 'Allow', methodArn);
+      return createAuthResult(verifiedToken.preferred_username || 'N/A', 'Allow', methodArn);
     }
 
     const result = await verifyExaminer(employeeId);
@@ -53,7 +53,7 @@ export async function handler(event: CustomAuthorizerEvent): Promise<CustomAutho
     // Default to DE role
     examinerRole = result.Item[role] as string || DE;
 
-    return createAuthResult(verifiedToken.unique_name, 'Allow', methodArn);
+    return createAuthResult(verifiedToken.preferred_username || 'N/A', 'Allow', methodArn);
   } catch (err) {
     return handleError(err, event, methodArn);
   }
@@ -84,7 +84,7 @@ function createAuthResult(
 async function handleError(err: any, event: CustomAuthorizerEvent, methodArn: string) {
   const id = employeeId || null;
   const name = verifiedToken ? verifiedToken.name : null;
-  const unique_name = verifiedToken ? verifiedToken.unique_name : null; // tslint:disable-line:variable-name
+  const preferred_username = verifiedToken ? verifiedToken.preferred_username : null; // tslint:disable-line:variable-name max-line-length
 
   const failedAuthDetails = {
     err,
@@ -94,7 +94,7 @@ async function handleError(err: any, event: CustomAuthorizerEvent, methodArn: st
     employee: {
       id,
       name,
-      unique_name,
+      preferred_username,
     },
   };
 

--- a/typings/jsonwebtoken.d.ts
+++ b/typings/jsonwebtoken.d.ts
@@ -18,7 +18,7 @@ declare module 'jsonwebtoken' {
 
   export interface TokenPayload {
     readonly sub: string;
-    readonly unique_name: string;
+    readonly preferred_username: string;
     readonly [propName: string]: any;
   }
 


### PR DESCRIPTION
- Uses the `preferred_username` claim from the AAD idToken to retrieve the user's email address.
- Tacks this value on to the auth result which then gets logged in CloudWatch as part of the access logs
- Tested against the dev environment, screenshot below

![image](https://user-images.githubusercontent.com/33695049/96249152-aad3ea00-0fa4-11eb-8400-20a87930c6c6.png)
