### PR TITLE
MES-5958: Use correct examiner details in error logs bugfix

### DIFF
--- a/src/functions/authoriser/framework/__tests__/handler.spec.ts
+++ b/src/functions/authoriser/framework/__tests__/handler.spec.ts
@@ -152,7 +152,7 @@ describe('handler', () => {
   });
 
   it('should return Deny when token verification fails', async () => {
-    testCustomAuthorizerEvent.authorizationToken = 'example-token';
+    testCustomAuthorizerEvent.authorizationToken = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6ImtnMkxZczJUMENUaklmajRydDZKSXluZW4zOCJ9.eyJhdWQiOiI5MjNiMDdkNC04MGVlLTQ1MjQtOGYzOC1jMTIzMGFlZmUxNTEiLCJpc3MiOiJodHRwczovL2xvZ2luLm1pY3Jvc29mdG9ubGluZS5jb20vNmM0NDhkOTAtNGNhMS00Y2FmLWFiNTktMGEyYWE2N2Q3ODAxL3YyLjAiLCJpYXQiOjE2MDMxMTQyMTUsIm5iZiI6MTYwMzExNDIxNSwiZXhwIjoxNjAzMTE1NzE1LCJhaW8iOiJBVFFBeS84UkFBQUFwNkNvV3VVZXNFV0hjZGRESTBVTXlMMi82OVdMcS9aVGJZTGZhU2RXRC9VYnc1a0drenVXYXNhZGVOWXlsVkVFIiwiYXpwIjoiOTIzYjA3ZDQtODBlZS00NTI0LThmMzgtYzEyMzBhZWZlMTUxIiwiYXpwYWNyIjoiMCIsImdyb3VwcyI6WyI0Y2RjYzBlMy1lYjRhLTQ1NDgtOTU2ZS0wNDY5MDNiN2JjMjAiXSwibmFtZSI6IlRTVCBERVMgRGVsZWdhdGVkRXhhbWluZXIgREVWIDEiLCJvaWQiOiJjZGU1YjljNC1iY2ZlLTQ5OGItYmM3ZC1mODU3MjYzODM3OWUiLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJUU1QuREVTLURlbGVnYXRlZC1ERVYxQGR2c2F0ZXN0LWNsb3VkLnVrIiwicmgiOiIwLkFBQUFrSTFFYktGTXIweXJXUW9xcG4xNEFkUUhPNUx1Z0NSRmp6akJJd3J2NFZGSUFIWS4iLCJyb2xlcyI6WyJEZWxFeGFtaW5lciJdLCJzY3AiOiJEaXJlY3RvcnkuQWNjZXNzQXNVc2VyLkFsbCBEaXJlY3RvcnkuUmVhZC5BbGwgZW1haWwgb2ZmbGluZV9hY2Nlc3Mgb3BlbmlkIHByb2ZpbGUgVXNlci5SZWFkIiwic3ViIjoieXdNUHJVdG41c1VQNFJleUpDTjRwLUI5dFh0R2w5aTV6LUxVMmdPVFRzTSIsInRpZCI6IjZjNDQ4ZDkwLTRjYTEtNGNhZi1hYjU5LTBhMmFhNjdkNzgwMSIsInV0aSI6IlpUX2ZOREtjUVVDbmI4VjZ3TDZQQUEiLCJ2ZXIiOiIyLjAiLCJ3aWRzIjpbImI3OWZiZjRkLTNlZjktNDY4OS04MTQzLTc2YjE5NGU4NTUwOSJdLCJlbXBsb3llZWlkIjoiMTAwMDAwMTQifQ.lVKgyWWJSl5HJuz9xpMv-j_cdc5J_Cx7AqnraVVbWWNNTbkNhIUV-qVh1GWi6llwEzjJ8YrK_TZXIumGO5jw1nhZw2a3cqGkqmiyri098nNmTmQBpP730R8WqogjOfwV3zFKQboJpxvZjQVQX7kLZyb1IT3CxE3gS5z31zxCOKr5LqnlvA9z6m55gBNIm2xGm-2-xepn8NYT1YplPwkFL4O0vY14uiyDY9Drwb8FyjAlW1trK1u_jOQS2ylT_zIZ0WG8m61DGoKNAAyl8obIPcVvruNHhwd1EV08Aa8yOPbvAKRw6O9EsTins97Ua7nu6Ln_Illait7Vemk-Mqy_5w';  // tslint:disable: max-line-length
     testCustomAuthorizerEvent.methodArn =
       'arn:aws:execute-api:region:account-id:api-id/stage-name/HTTP-VERB/resource/path/specifier';
 
@@ -177,13 +177,21 @@ describe('handler', () => {
       .toEqual('arn:aws:execute-api:region:account-id:api-id/stage-name/*/*');
     expect(result.principalId).toEqual('not-authorized');
 
-    mockAdJwtVerifier.verify(x => x.verifyJwt('example-token'), Times.once());
+    mockAdJwtVerifier.verify(x => x.verifyJwt(It.isAnyString()), Times.once());
 
     moqFailedAuthLogger.verify(
       x => x(
         It.is<string>(s => /Failed authorization\. Responding with Deny\./.test(s)),
         'error',
-        It.is<any>(o => /Example invalid token error/.test(o.failedAuthReason))),
+        It.isObjectWith({
+          failedAuthReason: 'Error: Example invalid token error',
+          employee: {
+            id: '12345678',
+            name: 'TST DES DelegatedExaminer DEV 1',
+            preferred_username: 'TST.DES-Delegated-DEV1@dvsatest-cloud.uk',
+          },
+        }),
+      ),
       Times.once());
   });
 

--- a/src/functions/authoriser/framework/handler.ts
+++ b/src/functions/authoriser/framework/handler.ts
@@ -88,7 +88,7 @@ async function handleError(err: any, event: CustomAuthorizerEvent, methodArn: st
   const decodedToken = decode(event.authorizationToken as string) as any;
   const id = extractEmployeeIdFromToken(decodedToken, employeeIdExtKey) || null;
   const name = decodedToken ? decodedToken.name : null;
-  const preferred_username = decodedToken ? decodedToken.preferred_username : null; // tslint:disable-line:variable-name max-line-length
+  const preferred_username = decodedToken ? decodedToken.preferred_username : null; // tslint:disable-line:variable-name
 
   const failedAuthDetails = {
     err,

--- a/src/functions/authoriser/framework/handler.ts
+++ b/src/functions/authoriser/framework/handler.ts
@@ -8,6 +8,7 @@ import verifyExaminer from '../application/verifyExaminer';
 import getEmployeeIdKey from '../application/getEmployeeIdKey';
 import { extractEmployeeIdFromToken } from '../application/extractEmployeeIdFromToken';
 import { hasDelegatedExaminerRole } from '../application/extractEmployeeRolesFromToken';
+import { decode } from 'jsonwebtoken';
 
 type Effect = 'Allow' | 'Deny';
 
@@ -82,9 +83,12 @@ function createAuthResult(
 }
 
 async function handleError(err: any, event: CustomAuthorizerEvent, methodArn: string) {
-  const id = employeeId || null;
-  const name = verifiedToken ? verifiedToken.name : null;
-  const preferred_username = verifiedToken ? verifiedToken.preferred_username : null; // tslint:disable-line:variable-name max-line-length
+
+  const employeeIdExtKey: EmployeeIdKey = getEmployeeIdKey();
+  const decodedToken = decode(event.authorizationToken as string) as any;
+  const id = extractEmployeeIdFromToken(decodedToken, employeeIdExtKey) || null;
+  const name = decodedToken ? decodedToken.name : null;
+  const preferred_username = decodedToken ? decodedToken.preferred_username : null; // tslint:disable-line:variable-name max-line-length
 
   const failedAuthDetails = {
     err,


### PR DESCRIPTION
Fixes a long-standing bug that affects the error logs on the custom authoriser. The variable that is responsible for reporting the employee details (`verifiedToken`) is only assigned if the expiry check is successful. In the event that the expiry check fails, the authoriser seems to use the value that exists from the previous authoriser execution which will be from a different examiner.

This change ensure that the authoriser uses the raw token from the request when logging errors. Tested successfully in the development environment.